### PR TITLE
Bug for Tick class for gcc < 11.2

### DIFF
--- a/plot.h
+++ b/plot.h
@@ -675,8 +675,10 @@ struct Tick {
 	Tick(double value, std::string name) : value(value), name(name) {}
 
 	template<typename T>
-	Tick(T v) : value(double(v)) {
-		name = (std::stringstream() << value).str();
+	Tick(T v) : value(static_cast<double>(v)) {
+		std::stringstream ss;
+		ss << value;
+		name = ss.str();
 	}
 };
 


### PR DESCRIPTION
Fix bug for gcc < 11.2

```bash
 class std::basic_ostream<char>' has no member named 'str'
  679 |   name = (std::stringstream() << value).str();
```

temporary std::stringstream instances don’t support direct access to str() for gcc < 11.2

Proposed solution (line 679) : 

```cpp
	template<typename T>
	Tick(T v) : value(static_cast<double>(v)) {
		std::stringstream ss;
		ss << value;
		name = ss.str();
	}
````